### PR TITLE
Expose "clipboard_operational" instruction to common client

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/Client.js
+++ b/guacamole-common-js/src/main/webapp/modules/Client.js
@@ -760,6 +760,13 @@ Guacamole.Client = function(tunnel) {
     this.onargv = null;
 
     /**
+     * Fired when the clipboard of the remote client becomes operational.
+     *
+     * @event
+     */
+    this.onclipboardoperational = null;
+
+    /**
      * Fired when the clipboard of the remote client is changing.
      * 
      * @event
@@ -1093,6 +1100,10 @@ Guacamole.Client = function(tunnel) {
 
             display.clip(layer);
 
+        },
+
+        "clipboard_operational": function() {
+            if (guac_client.onclipboardoperational) guac_client.onclipboardoperational();
         },
 
         "clipboard": function(parameters) {


### PR DESCRIPTION
Requires: https://github.com/Osirium/guacamole-server/pull/6

It's also worth taking a look at https://github.com/Osirium/guacamole-common-js/commit/7327cb62d5eb3b079adf68da8c4a0acf7bca412a